### PR TITLE
Fixed Component URLInput not honouring className

### DIFF
--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -227,11 +227,11 @@ class URLInput extends Component {
 	}
 
 	render() {
-		const { value = '', autoFocus = true, instanceId } = this.props;
+		const { value = '', autoFocus = true, instanceId, className } = this.props;
 		const { showSuggestions, posts, selectedSuggestion, loading } = this.state;
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
-			<div className="editor-url-input">
+			<div className={ classnames( 'editor-url-input', className ) }>
 				<input
 					autoFocus={ autoFocus }
 					type="text"


### PR DESCRIPTION
## Description
Related: #13754
This pull request fixes the URIInput Component not honouring. This add the className to the parent div for the component

## How has this been tested?
- Added className to the URLInput component "/packages/format-library/src/link/inline.js"
- Inspected element in browser for classname from link menu

Before Change:
The class was not appended to the URLInput class "editor-url-input"

After Change
The class was appended to the URLInput class "editor-url-input"

## Types of changes]
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
